### PR TITLE
fix backendRoute to handle leading slash, fix primer_design params

### DIFF
--- a/src/components/primers/primer_design/SequenceTabComponents/PrimerDesignContext.jsx
+++ b/src/components/primers/primer_design/SequenceTabComponents/PrimerDesignContext.jsx
@@ -195,9 +195,13 @@ export function PrimerDesignProvider({ children, designType, sequenceIds, primer
     let requestData;
     let params;
     let endpoint;
+    const paramsForRequest = Object.fromEntries(
+      Object.entries(primerDesignSettings)
+        .filter(([_, value]) => typeof value !== 'function'),
+    );
     if (designType === 'gibson_assembly') {
       params = {
-        ...primerDesignSettings,
+        ...paramsForRequest,
         circular: circularAssembly,
       };
       requestData = {
@@ -212,7 +216,7 @@ export function PrimerDesignProvider({ children, designType, sequenceIds, primer
     } else if (designType === 'homologous_recombination') {
       const [pcrTemplateId, homologousRecombinationTargetId] = sequenceIds;
       params = {
-        ...primerDesignSettings,
+        ...paramsForRequest,
       };
       requestData = {
         pcr_template: {
@@ -230,7 +234,7 @@ export function PrimerDesignProvider({ children, designType, sequenceIds, primer
     } else if (designType === 'simple_pair' || designType === 'gateway_bp' || designType === 'restriction_ligation') {
       const pcrTemplateId = sequenceIds[0];
       params = {
-        ...primerDesignSettings,
+        ...paramsForRequest,
       };
 
       requestData = {
@@ -250,11 +254,11 @@ export function PrimerDesignProvider({ children, designType, sequenceIds, primer
         // forward_orientation: fragmentOrientations[0] === 'forward',
       };
       params = {
-        ...primerDesignSettings,
+        ...paramsForRequest,
       };
     }
 
-    const url = backendRoute(`/primer_design/${endpoint}`);
+    const url = backendRoute(`primer_design/${endpoint}`);
 
     try {
       const resp = await httpClient.post(url, requestData, { params });

--- a/src/hooks/useBackendRoute.js
+++ b/src/hooks/useBackendRoute.js
@@ -15,6 +15,8 @@ export default function useBackendRoute() {
     //   console.log(new URL(import.meta.env.VITE_REACT_APP_BACKEND_URL, window.location.origin).href);
     // This handles both the case where the backend url is absolute and the case where it is relative
     const backendRoot = new URL(backendUrl, window.location.origin).href;
-    return new URL(path, backendRoot).href;
+    // Remove trailing slash from path
+    const sanitizedPath = path.endsWith('/') ? path.slice(0, -1) : path;
+    return new URL(sanitizedPath, backendRoot).href;
   };
 }


### PR DESCRIPTION
* Previously, it was including functions in the request parameters because it was doing `...primerDesignSettings`, and that included functions. Now it builds a new object that only has the non-function values.
* Also, it was calling `backendRoute(`/primer_design/${endpoint}`);` (with leading slash). Now it calls it without, and I also fixed backendRoute to remove leading slash. this was creating an error only detectable when ran on eLabFTW