### PR TITLE
Use assets site instead of raw.githubusercontent.com

### DIFF
--- a/cypress/e2e/group-3/source_repository_id.cy.js
+++ b/cypress/e2e/group-3/source_repository_id.cy.js
@@ -190,7 +190,7 @@ describe('RepositoryId Source', () => {
 
     // Displays the right links
     cy.get('li#source-1').contains('Plasmid BBa_B0012 containing part BBa_J428091 in backbone pSB1C5SD from 2024 iGEM Distribution').should('be.visible');
-    cy.get('li#source-1 a[href="https://raw.githubusercontent.com/manulera/annotated-igem-distribution/master/results/plasmids/1.gb"]').should('exist');
+    cy.get('li#source-1 a[href="https://assets.opencloning.org/annotated-igem-distribution/results/plasmids/1.gb"]').should('exist');
     cy.get('li#source-1 a[href="https://parts.igem.org/Part:BBa_J428091"]').should('exist');
     cy.get('li#source-1 a[href="https://airtable.com/appgWgf6EPX5gpnNU/shrb0c8oYTgpZDRgH/tblNqHsHbNNQP2HCX"]').should('exist');
 
@@ -201,7 +201,7 @@ describe('RepositoryId Source', () => {
     cy.get('li#sequence-2').contains('2432 bps');
 
     // Links to https://www.snapgene.com/plasmids/insect_cell_vectors/pFastBac1
-    cy.get('li#source-1 a[href="https://raw.githubusercontent.com/manulera/annotated-igem-distribution/master/results/plasmids/1.gb"]').should('exist');
+    cy.get('li#source-1 a[href="https://assets.opencloning.org/annotated-igem-distribution/results/plasmids/1.gb"]').should('exist');
     cy.get('li#source-1 a[href="https://parts.igem.org/Part:BBa_J428091"]').should('exist');
     cy.get('li#source-1 a[href="https://airtable.com/appgWgf6EPX5gpnNU/shrb0c8oYTgpZDRgH/tblNqHsHbNNQP2HCX"]').should('exist');
     cy.get('li#source-1 a[href="https://github.com/manulera/annotated-igem-distribution/blob/master/results/reports/1.csv"]').should('exist');

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -59,7 +59,7 @@ function App() {
           }
         } else if (urlParams.source === 'template' && urlParams.template && urlParams.key) {
           try {
-            const baseUrl = 'https://raw.githubusercontent.com/OpenCloning/OpenCloning-submission/master';
+            const baseUrl = 'https://assets.opencloning.org/OpenCloning-submission';
             const url = `${baseUrl}/processed/${urlParams.key}/templates/${urlParams.template}`;
             const { data } = await httpClient.get(url);
             dispatch(setCloningState(data));

--- a/src/components/navigation/SelectTemplateDialog.jsx
+++ b/src/components/navigation/SelectTemplateDialog.jsx
@@ -8,7 +8,7 @@ function SelectTemplateDialog({ onClose, open }) {
   const [templates, setTemplates] = React.useState(null);
   const [connectAttempt, setConnectAttemp] = React.useState(0);
   const [error, setError] = React.useState(null);
-  const baseUrl = 'https://raw.githubusercontent.com/OpenCloning/OpenCloning-submission/master';
+  const baseUrl = 'https://assets.opencloning.org/OpenCloning-submission';
   const httpClient = useHttpClient();
 
   // const baseUrl = '';

--- a/src/components/sources/SourceRepositoryId.jsx
+++ b/src/components/sources/SourceRepositoryId.jsx
@@ -77,7 +77,7 @@ function SnapgeneSuccessComponent({ option }) {
 
 const iGEMGetOptions = (plasmids, inputValue) => plasmids.map((p) => ({
   name: `${p['Short Desc / Name']} / ${p['Part Name']} / ${p['Plasmid Backbone']}`,
-  url: `https://raw.githubusercontent.com/manulera/annotated-igem-distribution/master/results/plasmids/${p['Index ID']}.gb`,
+  url: `https://assets.opencloning.org/annotated-igem-distribution/results/plasmids/${p['Index ID']}.gb`,
   table_name: p['Short Desc / Name'],
   part_name: p['Part Name'],
   part_url: p['Part URL'],
@@ -308,7 +308,7 @@ function SourceRepositoryId({ source, requestStatus, sendPostRequest }) {
           {selectedRepository === 'snapgene'
           && (
           <IndexJsonSelector
-            url="https://raw.githubusercontent.com/manulera/SnapGene_crawler/master/index.json"
+            url="https://assets.opencloning.org/SnapGene_crawler/index.json"
             setInputValue={setInputValue}
             getOptions={snapgeneGetOptions}
             noOptionsText="Type at least 3 characters to search, see SnapGene plasmids for options"
@@ -319,7 +319,7 @@ function SourceRepositoryId({ source, requestStatus, sendPostRequest }) {
           )}
           {selectedRepository === 'igem' && (
           <IndexJsonSelector
-            url="https://raw.githubusercontent.com/manulera/annotated-igem-distribution/master/results/index.json"
+            url="https://assets.opencloning.org/annotated-igem-distribution/results/index.json"
             setInputValue={setInputValue}
             getOptions={iGEMGetOptions}
             noOptionsText=""
@@ -330,7 +330,7 @@ function SourceRepositoryId({ source, requestStatus, sendPostRequest }) {
           )}
           {selectedRepository === 'seva' && (
             <IndexJsonSelector
-              url="https://raw.githubusercontent.com/manulera/seva_plasmids_index/master/index.json"
+              url="https://assets.opencloning.org/seva_plasmids_index/index.json"
               setInputValue={setInputValue}
               getOptions={sevaGetOptions}
               noOptionsText="Type at least 3 characters to search"

--- a/src/config/urlWhitelist.js
+++ b/src/config/urlWhitelist.js
@@ -1,12 +1,12 @@
 export default [
   // GitHub repository for OpenCloning templates
-  'https://raw.githubusercontent.com/OpenCloning/OpenCloning-submission/master',
+  'https://assets.opencloning.org/OpenCloning-submission',
   // GitHub repository for annotated iGEM distribution
-  'https://raw.githubusercontent.com/manulera/annotated-igem-distribution/master',
+  'https://assets.opencloning.org/annotated-igem-distribution',
   // GitHub repository for SEVA plasmids index
-  'https://raw.githubusercontent.com/manulera/seva_plasmids_index/master',
+  'https://assets.opencloning.org/seva_plasmids_index',
   // GitHub repository for SnapGene index
-  'https://raw.githubusercontent.com/manulera/SnapGene_crawler/master',
+  'https://assets.opencloning.org/SnapGene_crawler',
   // NCBI entrez API
   'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi',
   'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi',

--- a/src/utils/readNwrite.js
+++ b/src/utils/readNwrite.js
@@ -259,7 +259,7 @@ export function formatTemplate(data, url) {
   const newData = { ...data };
   const segments = url.split('/');
   const kitUrl = segments[segments.length - 3];
-  const rootGithubUrl = 'https://raw.githubusercontent.com/OpenCloning/OpenCloning-submission/master/submissions';
+  const rootGithubUrl = 'https://assets.opencloning.org/OpenCloning-submission/submissions';
   newData.sources = newData.sources.map((s) => ((s.image === undefined || s.image[0] === null) ? s : {
     ...s, image: [`${rootGithubUrl}/${kitUrl}/${s.image[0]}`, s.image[1]],
   }));


### PR DESCRIPTION
Closes #475. Instead of getting files from `raw.githubusercontent.com`, it gets them from a static site where all repository content is aggregated (https://assets.opencloning.org/).

See https://github.com/OpenCloning/OpenCloning_static_assets

The backend part is in https://github.com/manulera/OpenCloning_backend/pull/330