### PR TITLE
Add optional umami events to cloning actions

### DIFF
--- a/src/components/sources/CollectionSource.jsx
+++ b/src/components/sources/CollectionSource.jsx
@@ -80,10 +80,13 @@ function CollectionSource({ source, requestStatus, sendPostRequest }) {
         </FormControl>
 
         {selectedOption !== null && (
-        <>
-          {selectedOptionObject.info && <ObjectTable object={selectedOptionObject.info} />}
-          <SubmitButtonBackendAPI requestStatus={requestStatus}>Submit</SubmitButtonBackendAPI>
-        </>
+          <>
+            {selectedOptionObject.info && <ObjectTable object={selectedOptionObject.info} />}
+            <SubmitButtonBackendAPI
+              requestStatus={requestStatus}
+              {...(import.meta.env.VITE_UMAMI_WEBSITE_ID && { "data-umami-event": "submit-collection-source" })}
+            >Submit</SubmitButtonBackendAPI>
+          </>
         )}
       </form>
     </div>

--- a/src/components/sources/SourceAnnotation.jsx
+++ b/src/components/sources/SourceAnnotation.jsx
@@ -33,7 +33,10 @@ function SourceAnnotation({ source, requestStatus, sendPostRequest }) {
           <MenuItem value="plannotate">pLannotate</MenuItem>
         </Select>
       </FormControl>
-      <SubmitButtonBackendAPI requestStatus={requestStatus}>Annotate</SubmitButtonBackendAPI>
+      <SubmitButtonBackendAPI
+        requestStatus={requestStatus}
+        {...(import.meta.env.VITE_UMAMI_WEBSITE_ID && { "data-umami-event": "submit-annotation" })}
+      >Annotate</SubmitButtonBackendAPI>
     </form>
   );
 }

--- a/src/components/sources/SourceAssembly.jsx
+++ b/src/components/sources/SourceAssembly.jsx
@@ -187,7 +187,12 @@ function SourceAssembly({ source, requestStatus, sendPostRequest }) {
         </FormControl>
         )}
 
-        {!preventSubmit && <SubmitButtonBackendAPI requestStatus={requestStatus}>Submit</SubmitButtonBackendAPI>}
+        {!preventSubmit && (
+          <SubmitButtonBackendAPI
+            requestStatus={requestStatus}
+            {...(import.meta.env.VITE_UMAMI_WEBSITE_ID && { "data-umami-event": `submit-assembly-${assemblyType}` })}
+          >Submit</SubmitButtonBackendAPI>
+        )}
       </form>
     </div>
   );

--- a/src/components/sources/SourceFile.jsx
+++ b/src/components/sources/SourceFile.jsx
@@ -171,6 +171,7 @@ function SourceFile({ source, requestStatus, sendPostRequest }) {
       <SubmitButtonBackendAPI
         component="label"
         requestStatus={requestStatus}
+        {...(import.meta.env.VITE_UMAMI_WEBSITE_ID && { "data-umami-event": "submit-file" })}
       >
         Select File
         <input

--- a/src/components/sources/SourceGenomeRegion.jsx
+++ b/src/components/sources/SourceGenomeRegion.jsx
@@ -112,7 +112,12 @@ function SourceGenomeRegionLocusOnReference({ source, requestStatus, sendPostReq
         <>
           <KnownAssemblyField assemblyId={assemblyId} />
           <SourceGenomeRegionSelectGene {...{ gene, upstreamBasesRef, downstreamBasesRef, setGene, assemblyId }} />
-          {gene && <SubmitButtonBackendAPI requestStatus={requestStatus}>Submit</SubmitButtonBackendAPI>}
+          {gene && (
+            <SubmitButtonBackendAPI
+              requestStatus={requestStatus}
+              {...(import.meta.env.VITE_UMAMI_WEBSITE_ID && { "data-umami-event": "submit-genome-region-locus-reference" })}
+            >Submit</SubmitButtonBackendAPI>
+          )}
         </>
       )}
       { (species && assemblyId === '') && (
@@ -221,7 +226,12 @@ function SourceGenomeRegionLocusOnOther({ source, requestStatus, sendPostRequest
       {assemblyId && hasAnnotation && (
         <>
           <SourceGenomeRegionSelectGene {...{ gene, upstreamBasesRef, downstreamBasesRef, setGene, assemblyId }} />
-          {gene && <SubmitButtonBackendAPI requestStatus={requestStatus}>Submit</SubmitButtonBackendAPI>}
+          {gene && (
+            <SubmitButtonBackendAPI
+              requestStatus={requestStatus}
+              {...(import.meta.env.VITE_UMAMI_WEBSITE_ID && { "data-umami-event": "submit-genome-region-locus-other" })}
+            >Submit</SubmitButtonBackendAPI>
+          )}
         </>
       )}
       {assemblyId && !hasAnnotation && (<Alert severity="error">The selected assembly has no gene annotations</Alert>)}
@@ -360,7 +370,10 @@ function SourceGenomeRegionCustomCoordinates({ source, requestStatus, sendPostRe
               <FormHelperText error={formError.strand !== null}>{formError.strand}</FormHelperText>
             </FormControl>
           </Box>
-          <SubmitButtonBackendAPI requestStatus={requestStatus}>Submit</SubmitButtonBackendAPI>
+          <SubmitButtonBackendAPI
+            requestStatus={requestStatus}
+            {...(import.meta.env.VITE_UMAMI_WEBSITE_ID && { "data-umami-event": "submit-genome-region-custom-coordinates" })}
+          >Submit</SubmitButtonBackendAPI>
         </>
       )}
     </form>

--- a/src/components/sources/SourceHomologousRecombination.jsx
+++ b/src/components/sources/SourceHomologousRecombination.jsx
@@ -109,7 +109,11 @@ function SourceHomologousRecombination({ source, requestStatus, sendPostRequest 
           />
         )}
         { allowSubmit && (
-        <SubmitButtonBackendAPI requestStatus={requestStatus} color="primary">
+        <SubmitButtonBackendAPI
+          requestStatus={requestStatus}
+          color="primary"
+          {...(import.meta.env.VITE_UMAMI_WEBSITE_ID && { "data-umami-event": isCrispr ? "submit-crispr" : "submit-homologous-recombination" })}
+        >
           {isCrispr ? 'Perform CRISPR' : 'Recombine'}
         </SubmitButtonBackendAPI>
         )}

--- a/src/components/sources/SourceManuallyTyped.jsx
+++ b/src/components/sources/SourceManuallyTyped.jsx
@@ -102,7 +102,10 @@ function SourceManuallyTyped({ source, requestStatus, sendPostRequest }) {
       <FormControl fullWidth style={{ textAlign: 'left' }}>
         <FormControlLabel control={<Checkbox value={isCircular} onChange={onCircularChange} />} label="Circular DNA" />
       </FormControl>
-      <SubmitButtonBackendAPI requestStatus={requestStatus}>Submit</SubmitButtonBackendAPI>
+      <SubmitButtonBackendAPI
+        requestStatus={requestStatus}
+        {...(import.meta.env.VITE_UMAMI_WEBSITE_ID && { "data-umami-event": "submit-manually-typed" })}
+      >Submit</SubmitButtonBackendAPI>
     </form>
   );
 }

--- a/src/components/sources/SourcePCRorHybridization.jsx
+++ b/src/components/sources/SourcePCRorHybridization.jsx
@@ -150,7 +150,10 @@ function SourcePCRorHybridization({ source, requestStatus, sendPostRequest }) {
           </>
         )}
         {forwardPrimerId && reversePrimerId && (
-          <SubmitButtonBackendAPI requestStatus={requestStatus}>
+          <SubmitButtonBackendAPI
+            requestStatus={requestStatus}
+            {...(import.meta.env.VITE_UMAMI_WEBSITE_ID && { "data-umami-event": !isPcr ? "submit-hybridization" : "submit-pcr" })}
+          >
             {!isPcr ? 'Perform hybridization' : 'Perform PCR'}
           </SubmitButtonBackendAPI>
         )}

--- a/src/components/sources/SourcePolymeraseExtension.jsx
+++ b/src/components/sources/SourcePolymeraseExtension.jsx
@@ -29,7 +29,10 @@ function SourcePolymeraseExtension({ source, requestStatus, sendPostRequest }) {
             no 5&apos; overhangs.
           </Alert>
         ) : (
-          <SubmitButtonBackendAPI requestStatus={requestStatus}>
+          <SubmitButtonBackendAPI
+            requestStatus={requestStatus}
+            {...(import.meta.env.VITE_UMAMI_WEBSITE_ID && { "data-umami-event": "submit-polymerase-extension" })}
+          >
             Extend with polymerase
           </SubmitButtonBackendAPI>
         )}

--- a/src/components/sources/SourceRepositoryId.jsx
+++ b/src/components/sources/SourceRepositoryId.jsx
@@ -404,7 +404,12 @@ function SourceRepositoryId({ source, requestStatus, sendPostRequest }) {
               groupField="collection"
             />
           )}
-          {inputValue && !error && (<SubmitButtonBackendAPI requestStatus={requestStatus}>Submit</SubmitButtonBackendAPI>)}
+          {inputValue && !error && (
+            <SubmitButtonBackendAPI
+              requestStatus={requestStatus}
+              {...(import.meta.env.VITE_UMAMI_WEBSITE_ID && { "data-umami-event": "submit-repository-id" })}
+            >Submit</SubmitButtonBackendAPI>
+          )}
 
         </form>
       )}

--- a/src/components/sources/SourceRestriction.jsx
+++ b/src/components/sources/SourceRestriction.jsx
@@ -26,7 +26,13 @@ function SourceRestriction({ source, requestStatus, sendPostRequest }) {
     <div className="restriction">
       <form onSubmit={onSubmit}>
         <EnzymeMultiSelect setEnzymes={setEnzymes} />
-        {(enzymes.length > 0) && <SubmitButtonBackendAPI requestStatus={requestStatus} color="success">Perform restriction</SubmitButtonBackendAPI>}
+        {(enzymes.length > 0) && (
+          <SubmitButtonBackendAPI
+            requestStatus={requestStatus}
+            color="success"
+            {...(import.meta.env.VITE_UMAMI_WEBSITE_ID && { "data-umami-event": "submit-restriction" })}
+          >Perform restriction</SubmitButtonBackendAPI>
+        )}
       </form>
     </div>
   );

--- a/src/components/sources/SourceReverseComplement.jsx
+++ b/src/components/sources/SourceReverseComplement.jsx
@@ -19,7 +19,10 @@ function SourceReverseComplement({ source, requestStatus, sendPostRequest }) {
   return (
     <div className="ReverseComplementSource">
       <form onSubmit={onSubmit}>
-        <SubmitButtonBackendAPI requestStatus={requestStatus}>
+        <SubmitButtonBackendAPI
+          requestStatus={requestStatus}
+          {...(import.meta.env.VITE_UMAMI_WEBSITE_ID && { "data-umami-event": "submit-reverse-complement" })}
+        >
           Reverse complement
         </SubmitButtonBackendAPI>
       </form>


### PR DESCRIPTION
* These are unset by default, but will be set if `VITE_UMAMI_WEBSITE_ID` is set at build time.
* This only happens when building the hosted version in the post_release action.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds conditional Umami tracking (data-umami-event) to Submit buttons across cloning source forms when VITE_UMAMI_WEBSITE_ID is set.
> 
> - **Analytics instrumentation**
>   - Conditionally adds `data-umami-event` to `SubmitButtonBackendAPI` across source components when `VITE_UMAMI_WEBSITE_ID` exists.
>   - Dynamic event names per action/context:
>     - `CollectionSource`: `submit-collection-source`
>     - `SourceAnnotation`: `submit-annotation`
>     - `SourceAssembly`: `submit-assembly-<assemblyType>`
>     - `SourceFile`: `submit-file`
>     - `SourceGenomeRegion`:
>       - Locus (reference): `submit-genome-region-locus-reference`
>       - Locus (other): `submit-genome-region-locus-other`
>       - Custom coordinates: `submit-genome-region-custom-coordinates`
>     - `SourceHomologousRecombination`: `submit-crispr` or `submit-homologous-recombination`
>     - `SourceManuallyTyped`: `submit-manually-typed`
>     - `SourcePCRorHybridization`: `submit-pcr` or `submit-hybridization`
>     - `SourcePolymeraseExtension`: `submit-polymerase-extension`
>     - `SourceRepositoryId`: `submit-repository-id`
>     - `SourceRestriction`: `submit-restriction`
>     - `SourceReverseComplement`: `submit-reverse-complement`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f5e02f6134e8e38328e2b2bcdf4e5b0686bd863. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->